### PR TITLE
Fix Stable Swap Calculation Error in Numerical Example 7

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -246,9 +246,9 @@ This paper details all mathematics and applies them to a numerical example with 
   - \( U_{val,7} = 11 + 22.0022 + 22.0022 + 45.5556 \approx 100.56 \) (includes 1 USDV input).
 - **Stable Swap**:
   - \( \Delta X = 8.9802 \).
-  - \( \Delta Y = 90 - \frac{180}{90 + 8.9802} = 90 - \frac{180}{98.9802} \approx 90 - 81.8335 = 8.1665 \).
-  - \( X = 90 + 8.9802 = 98.9802 \), \( Y = 90 - 8.1665 = 81.8335 \).
-  - Charlie: \( S_{v,7}(3, Charlie) = 0 \), 8.1665 TTDC.
+  - \( \Delta Y = \Delta X = 8.9802 \).
+  - \( X = 90 + 8.9802 = 98.9802 \), \( Y = 90 - 8.9802 = 81.0198 \).
+  - Charlie: \( S_{v,7}(3, Charlie) = 0 \), 8.9802 TTDC.
 
 ---
 


### PR DESCRIPTION
This PR corrects an error in the Stable Swap calculation at step \( n = 7 \) in the VFE-TTD numerical example. The original calculation for \(\Delta Y_c\) (TTDC output) used an incorrect formula `(\( 90 - \frac{180}{90 + 8.9802} \approx 8.1665 \)),` which does not align with the Constant Sum AMM (CSAMM) design (\( X_v + Y_c = k_{ss} \)) that should provide a 1:1 swap. The corrected output is `\(\Delta Y_c = \Delta X_v = 8.9802\)`, matching Charlie’s TTDV input of 8.9802. The pool state is updated accordingly to maintain` \( k_{ss} = 180 \)`.

Changes:
- Updated \(\Delta Y_c\) from 8.1665 to 8.9802.
- Adjusted \( Y_{c,7} \) from 81.8335 to 81.0198.
- Corrected Charlie’s received TTDC from 8.1665 to 8.9802.